### PR TITLE
fix: format date in Mood Tracker history 

### DIFF
--- a/components/features/MoodTracker/MoodRecords/MoodRecordsList/MoodRecordsList.tsx
+++ b/components/features/MoodTracker/MoodRecords/MoodRecordsList/MoodRecordsList.tsx
@@ -8,6 +8,7 @@ import { FOCUSES } from '@/constants/focus'
 import { MOODS } from '@/constants/moods'
 import { STRESSES } from '@/constants/stress'
 import { Tag } from '@/ds/components/Tag'
+import { formatDate } from '@/helpers/data'
 import type { MoodRecordEntity } from '@/types/api-responses'
 
 type Props = {
@@ -15,7 +16,6 @@ type Props = {
 }
 
 export function MoodRecordsList({ records }: Props) {
-  const locale = useLocale()
   const t = useTranslations('components.Mood')
   const commonGeneral = useTranslations('common.General')
   const ts = useTranslations('components.StressLevelScale')
@@ -30,7 +30,7 @@ export function MoodRecordsList({ records }: Props) {
         const moodInfo = MOODS[moodIndex - 1]
         const IconComponent = moodInfo.icon
         const label = t(moodInfo.label as string)
-        const date = r.createdAt ? new Date(r.createdAt).toLocaleString(locale) : ''
+        const date = r.createdAt ? formatDate(new Date(r.createdAt).toISOString()) : ''
 
         const stressInfo = STRESSES.find((s) => s.value === r.stressLevel) ?? STRESSES[0]
         const energyInfo = ENERGIES.find((e) => e.value === r.energyLevel) ?? ENERGIES[2]

--- a/components/features/MoodTracker/MoodRecords/MoodRecordsList/MoodRecordsList.tsx
+++ b/components/features/MoodTracker/MoodRecords/MoodRecordsList/MoodRecordsList.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useLocale, useTranslations } from 'next-intl'
+import { useTranslations } from 'next-intl'
 
 import Card from '@/components/shared/Cards/Card'
 import { ENERGIES } from '@/constants/energy'


### PR DESCRIPTION
FIx #360 

-changed the date format to the one commonly used in the project

before: 
<img width="1118" height="331" alt="wrong-date-format" src="https://github.com/user-attachments/assets/3c423884-d70d-4b68-aceb-567a7af784a6" />

after:
<img width="1401" height="417" alt="correct-date-format" src="https://github.com/user-attachments/assets/3488bf3d-63a1-458b-b83c-7537af282149" />
