### PR TITLE
style: mobile ui improvements

### DIFF
--- a/app/[locale]/(protected)/layout.tsx
+++ b/app/[locale]/(protected)/layout.tsx
@@ -2,8 +2,10 @@ import { ReactNode } from 'react'
 
 import { LandingFooter } from '@/components/features/Landing'
 import { Header } from '@/components/Layout/Header'
+import { mainVariants } from '@/components/Layout/mainVariants'
 import Sidebar from '@/components/Layout/Sidebar/Sidebar'
 import { userSidebarMenu } from '@/constants/menu'
+import { cn } from '@/lib/utils'
 
 export default function ProtectedLayout({ children }: { children: ReactNode }) {
   return (
@@ -16,7 +18,7 @@ export default function ProtectedLayout({ children }: { children: ReactNode }) {
         <div className="hidden bg-white lg:flex">
           <Sidebar menu={userSidebarMenu} />
         </div>
-        <main className="old-paper min-h-screen w-full min-w-0 flex-1 flex-col items-start justify-between">
+        <main className={cn(mainVariants(), 'min-w-0')}>
           <div className="padded flex w-full flex-col gap-sm tablet:gap-6 sm:gap-md">
             <Header />
             {children}

--- a/app/[locale]/(protected)/layout.tsx
+++ b/app/[locale]/(protected)/layout.tsx
@@ -13,11 +13,11 @@ export default function ProtectedLayout({ children }: { children: ReactNode }) {
         <div className="h-full w-1/2 bg-background-alt" />
       </div>
       <div className="container-max-width relative z-10 flex w-full">
-        <div className="hidden bg-white md:flex">
+        <div className="hidden bg-white lg:flex">
           <Sidebar menu={userSidebarMenu} />
         </div>
-        <main className="old-paper min-h-screen w-full flex-1 flex-col items-start justify-between">
-          <div className="padded flex w-full flex-col gap-md">
+        <main className="old-paper min-h-screen w-full min-w-0 flex-1 flex-col items-start justify-between">
+          <div className="padded flex w-full flex-col gap-sm tablet:gap-6 sm:gap-md">
             <Header />
             {children}
           </div>

--- a/app/[locale]/(protected)/layout.tsx
+++ b/app/[locale]/(protected)/layout.tsx
@@ -18,7 +18,7 @@ export default function ProtectedLayout({ children }: { children: ReactNode }) {
         <div className="hidden bg-white lg:flex">
           <Sidebar menu={userSidebarMenu} />
         </div>
-        <main className={cn(mainVariants(), 'min-w-0')}>
+        <main className={cn(mainVariants())}>
           <div className="padded flex w-full flex-col gap-sm tablet:gap-6 sm:gap-md">
             <Header />
             {children}

--- a/app/[locale]/company/admin/layout.tsx
+++ b/app/[locale]/company/admin/layout.tsx
@@ -21,7 +21,7 @@ export default async function CompanyAdminLayout({ children }: { children: React
           <div className="h-full w-1/2 bg-background-alt" />
         </div>
         <div className="container-max-width relative z-10 flex w-full">
-          <div className="hidden bg-white md:flex">
+          <div className="hidden bg-white lg:flex">
             <Sidebar menu={companyAdminSidebarMenu} extra={extra} />
           </div>
           <main className="old-paper min-h-screen w-full flex-1 flex-col items-start justify-between">

--- a/app/[locale]/company/admin/layout.tsx
+++ b/app/[locale]/company/admin/layout.tsx
@@ -4,6 +4,7 @@ import { AdminCompanySelector } from '@/components/features/Company/AdminCompany
 import { AdminLayoutProvider } from '@/components/features/Company/AdminLayoutProvider'
 import { LandingFooter } from '@/components/features/Landing'
 import { CompanyHeader } from '@/components/Layout/Header/CompanyHeader'
+import { mainVariants } from '@/components/Layout/mainVariants'
 import Sidebar from '@/components/Layout/Sidebar/Sidebar'
 import { companyAdminSidebarMenu } from '@/constants/menu'
 import { getServerSession } from '@/lib/get-server-session'
@@ -24,7 +25,7 @@ export default async function CompanyAdminLayout({ children }: { children: React
           <div className="hidden bg-white lg:flex">
             <Sidebar menu={companyAdminSidebarMenu} extra={extra} />
           </div>
-          <main className="old-paper min-h-screen w-full flex-1 flex-col items-start justify-between">
+          <main className={mainVariants()}>
             <div className="padded flex w-full flex-col gap-md">
               <CompanyHeader menu={companyAdminSidebarMenu} extra={extra} />
               {children}

--- a/app/[locale]/company/manager/layout.tsx
+++ b/app/[locale]/company/manager/layout.tsx
@@ -21,7 +21,7 @@ export default async function CompanyManagerLayout({ children }: { children: Rea
           <div className="h-full w-1/2 bg-background-alt" />
         </div>
         <div className="container-max-width relative z-10 flex w-full">
-          <div className="hidden bg-white md:flex">
+          <div className="hidden bg-white lg:flex">
             <Sidebar menu={companyManagerSidebarMenu} extra={extra} />
           </div>
           <main className="old-paper min-h-screen w-full flex-1 flex-col items-start justify-between">

--- a/app/[locale]/company/manager/layout.tsx
+++ b/app/[locale]/company/manager/layout.tsx
@@ -4,6 +4,7 @@ import { AdminCompanySelector } from '@/components/features/Company/AdminCompany
 import { AdminLayoutProvider } from '@/components/features/Company/AdminLayoutProvider'
 import { LandingFooter } from '@/components/features/Landing'
 import { CompanyHeader } from '@/components/Layout/Header/CompanyHeader'
+import { mainVariants } from '@/components/Layout/mainVariants'
 import Sidebar from '@/components/Layout/Sidebar/Sidebar'
 import { companyManagerSidebarMenu } from '@/constants/menu'
 import { getServerSession } from '@/lib/get-server-session'
@@ -24,7 +25,7 @@ export default async function CompanyManagerLayout({ children }: { children: Rea
           <div className="hidden bg-white lg:flex">
             <Sidebar menu={companyManagerSidebarMenu} extra={extra} />
           </div>
-          <main className="old-paper min-h-screen w-full flex-1 flex-col items-start justify-between">
+          <main className={mainVariants()}>
             <div className="padded flex w-full flex-col gap-md">
               <CompanyHeader menu={companyManagerSidebarMenu} extra={extra} />
               {children}

--- a/app/[locale]/company/page.tsx
+++ b/app/[locale]/company/page.tsx
@@ -37,7 +37,8 @@ export default async function CompanyDashboardPage({ params }: { params: Promise
         <div className="h-full w-1/2 bg-background-alt" />
       </div>
       <div className="container-max-width relative z-10 flex w-full">
-        <main className="old-paper min-h-screen w-full flex-1 flex-col items-start justify-between">
+        {/* TODO: temporary rounded is none because don't have sidebar in this page */}
+        <main className="old-paper min-h-screen w-full flex-1 flex-col items-start justify-between rounded-none">
           <div className="padded flex w-full flex-col gap-sm tablet:gap-6 sm:gap-md">
             <CompanyHeader />
             <PageTitle title={t('title')} />

--- a/app/[locale]/company/page.tsx
+++ b/app/[locale]/company/page.tsx
@@ -4,6 +4,7 @@ import { getTranslations } from 'next-intl/server'
 
 import { LandingFooter } from '@/components/features/Landing'
 import { CompanyHeader } from '@/components/Layout/Header/CompanyHeader'
+import { mainVariants } from '@/components/Layout/mainVariants'
 import { Routes } from '@/constants/routes'
 import { PageTitle } from '@/ds/components/PageTitle'
 import { Link } from '@/i18n/navigation'
@@ -37,8 +38,7 @@ export default async function CompanyDashboardPage({ params }: { params: Promise
         <div className="h-full w-1/2 bg-background-alt" />
       </div>
       <div className="container-max-width relative z-10 flex w-full">
-        {/* TODO: temporary rounded is none because don't have sidebar in this page */}
-        <main className="old-paper min-h-screen w-full flex-1 flex-col items-start justify-between rounded-none">
+        <main className={mainVariants({ layout: 'noSidebar' })}>
           <div className="padded flex w-full flex-col gap-sm tablet:gap-6 sm:gap-md">
             <CompanyHeader />
             <PageTitle title={t('title')} />

--- a/app/[locale]/company/page.tsx
+++ b/app/[locale]/company/page.tsx
@@ -38,7 +38,7 @@ export default async function CompanyDashboardPage({ params }: { params: Promise
       </div>
       <div className="container-max-width relative z-10 flex w-full">
         <main className="old-paper min-h-screen w-full flex-1 flex-col items-start justify-between">
-          <div className="padded flex w-full flex-col gap-md">
+          <div className="padded flex w-full flex-col gap-sm tablet:gap-6 sm:gap-md">
             <CompanyHeader />
             <PageTitle title={t('title')} />
 

--- a/components/Layout/Header/CompanyHeader.tsx
+++ b/components/Layout/Header/CompanyHeader.tsx
@@ -21,12 +21,12 @@ export const CompanyHeader = ({ menu, extra }: { menu?: SidebarMenuItemType[]; e
     >
       <div className="flex items-center gap-sm">
         <CompanyMobileNavDrawer menu={menu} extra={extra} />
-        <span className="hidden md:block">
+        <span className="hidden xl:block">
           <LocalDate />
         </span>
       </div>
-      <div className="flex items-center gap-sm md:gap-md">
-        <TopMenu menu={userTopMenu} />
+      <div className="flex items-center gap-2 md:gap-md">
+        <TopMenu menu={userTopMenu} collapseToMyDayOnTablet={true} />
         <SearchBar isMobileOpen={isMobileOpen} setIsMobileOpen={setIsMobileOpen} />
         <LangSwitch />
         <AvatarMenu />

--- a/components/Layout/Header/CompanyHeader.tsx
+++ b/components/Layout/Header/CompanyHeader.tsx
@@ -1,25 +1,36 @@
+'use client'
+
+import { useState } from 'react'
+
 import { AvatarMenu, LocalDate, SearchBar } from '@/components/Layout/Header'
 import LangSwitch from '@/components/Layout/Header/LangSwitch'
 import CompanyMobileNavDrawer from '@/components/Layout/MobileNavDrawer/CompanyMobileNavDrawer'
 import { SidebarMenuItemType, userTopMenu } from '@/constants/menu'
+import { cn } from '@/lib/utils'
 
 import TopMenu from '../TopMenu/TopMenu'
 
-export const CompanyHeader = ({ menu, extra }: { menu?: SidebarMenuItemType[]; extra?: React.ReactNode }) => (
-  <header className="text-remark shadow-light flex w-full items-center justify-between gap-sm md:px-1">
-    <div className="flex items-center gap-sm">
-      <CompanyMobileNavDrawer menu={menu} extra={extra} />
-      <span className="hidden md:block">
-        <LocalDate />
-      </span>
-    </div>
-    <div className="flex items-center gap-sm md:gap-md">
-      <TopMenu menu={userTopMenu} />
-      <span className="hidden w-40 laptop:block">
-        <SearchBar />
-      </span>
-      <LangSwitch />
-      <AvatarMenu />
-    </div>
-  </header>
-)
+export const CompanyHeader = ({ menu, extra }: { menu?: SidebarMenuItemType[]; extra?: React.ReactNode }) => {
+  const [isMobileOpen, setIsMobileOpen] = useState(false)
+  return (
+    <header
+      className={cn(
+        'text-remark shadow-light flex w-full items-center justify-between gap-sm md:px-1',
+        isMobileOpen ? 'mb-6' : ''
+      )}
+    >
+      <div className="flex items-center gap-sm">
+        <CompanyMobileNavDrawer menu={menu} extra={extra} />
+        <span className="hidden md:block">
+          <LocalDate />
+        </span>
+      </div>
+      <div className="flex items-center gap-sm md:gap-md">
+        <TopMenu menu={userTopMenu} />
+        <SearchBar isMobileOpen={isMobileOpen} setIsMobileOpen={setIsMobileOpen} />
+        <LangSwitch />
+        <AvatarMenu />
+      </div>
+    </header>
+  )
+}

--- a/components/Layout/Header/Header.tsx
+++ b/components/Layout/Header/Header.tsx
@@ -1,27 +1,39 @@
+'use client'
+
+import { useState } from 'react'
+
 import { AvatarMenu, LocalDate, SearchBar } from '@/components/Layout/Header'
 import LangSwitch from '@/components/Layout/Header/LangSwitch'
 import MobileNavDrawer from '@/components/Layout/MobileNavDrawer/MobileNavDrawer'
 import { userTopMenu } from '@/constants/menu'
+import { cn } from '@/lib/utils'
 
 import TopMenu from '../TopMenu/TopMenu'
 
-const Header = () => (
-  <header className="text-remark shadow-light flex w-full items-center justify-between gap-sm md:px-1">
-    <div className="flex items-center gap-sm">
-      <MobileNavDrawer />
-      <span className="hidden md:block">
-        <LocalDate />
-      </span>
-    </div>
-    <div className="flex items-center gap-sm md:gap-md">
-      <TopMenu menu={userTopMenu} />
-      <span className="hidden w-40 laptop:block">
-        <SearchBar />
-      </span>
-      <LangSwitch />
-      <AvatarMenu />
-    </div>
-  </header>
-)
+const Header = () => {
+  const [isMobileOpen, setIsMobileOpen] = useState(false)
+
+  return (
+    <header
+      className={cn(
+        'text-remark shadow-light flex w-full items-center justify-between gap-2 tablet:mb-0 md:px-1',
+        isMobileOpen ? 'mb-6' : ''
+      )}
+    >
+      <div className="flex items-center gap-sm">
+        <MobileNavDrawer />
+        <span className="hidden xl:block">
+          <LocalDate />
+        </span>
+      </div>
+      <div className="flex items-center gap-2 md:gap-md">
+        <TopMenu collapseToMyDayOnTablet={true} menu={userTopMenu} />
+        <SearchBar isMobileOpen={isMobileOpen} setIsMobileOpen={setIsMobileOpen} />
+        <LangSwitch />
+        <AvatarMenu />
+      </div>
+    </header>
+  )
+}
 
 export default Header

--- a/components/Layout/Header/SearchBar.tsx
+++ b/components/Layout/Header/SearchBar.tsx
@@ -1,13 +1,20 @@
 'use client'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { X } from 'lucide-react'
+import { Search, X } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 
 import { searchItems } from '@/constants/searchItems'
 import { CustomInput } from '@/ds/components/CustomInput'
 import { Link, useRouter } from '@/i18n/navigation'
+import { cn } from '@/lib/utils'
 
-const SearchBar = () => {
+const SearchBar = ({
+  isMobileOpen,
+  setIsMobileOpen,
+}: {
+  isMobileOpen: boolean
+  setIsMobileOpen: (open: boolean) => void
+}) => {
   const t = useTranslations('components.Header.SearchBar')
   const tMenu = useTranslations('common.menu')
   const router = useRouter()
@@ -37,8 +44,9 @@ const SearchBar = () => {
       clearSearch()
       inputRef.current?.blur()
       router.push(href)
+      setIsMobileOpen(false)
     },
-    [clearSearch, router]
+    [clearSearch, router, setIsMobileOpen]
   )
 
   const handleKeyDown = useCallback(
@@ -87,65 +95,83 @@ const SearchBar = () => {
     const handleClickOutside = (e: MouseEvent) => {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
         setIsOpen(false)
+        setIsMobileOpen(false)
       }
     }
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [])
+  }, [setIsMobileOpen])
 
   return (
-    <div ref={containerRef} className="relative">
-      <CustomInput
-        ref={inputRef}
-        id="search"
-        placeholder={t('placeholder')}
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        onFocus={() => query.trim() && setIsOpen(true)}
-        onKeyDown={handleKeyDown}
-        rightIcon={query ? <X size={16} /> : undefined}
-        onRightClick={clearSearch}
-        role="combobox"
-        aria-expanded={isOpen}
-        aria-autocomplete="list"
-        aria-controls="search-results"
-        aria-activedescendant={isOpen && activeIndex >= 0 ? `search-option-${activeIndex}` : undefined}
-        className="placeholder-textcolor-tertiary h-8 border-none bg-background caret-textcolor-primary hover:bg-background-soft focus:placeholder-transparent focus-visible:bg-background-soft"
-      />
-      {isOpen && (
-        <ul
-          id="search-results"
-          role="listbox"
-          className="absolute top-full z-50 mt-1 max-h-64 w-full overflow-y-auto rounded-md border bg-white shadow-lg"
-        >
-          {filteredItems.length > 0 ? (
-            filteredItems.map((item, index) => (
-              <li key={item.key} id={`search-option-${index}`} role="option" aria-selected={index === activeIndex}>
-                <Link
-                  href={item.href}
-                  onClick={() => clearSearch()}
-                  className={`block px-3 py-2 text-sm ${
-                    index === activeIndex
-                      ? 'bg-background-soft text-textcolor-primary'
-                      : 'text-textcolor-secondary hover:bg-background-soft'
-                  }`}
-                >
-                  {tMenu(item.key)}
-                </Link>
+    <div ref={containerRef} className="flex items-center tablet:relative">
+      <button
+        type="button"
+        aria-label={t('placeholder')}
+        className={cn('sm:hidden', isMobileOpen && 'hidden')}
+        onClick={() => setIsMobileOpen(true)}
+      >
+        <Search size={18} />
+      </button>
+
+      <div
+        className={cn(isMobileOpen ? 'absolute left-4 right-4 top-14 z-50 flex' : 'hidden sm:block', 'tablet:static')}
+      >
+        <CustomInput
+          ref={inputRef}
+          id="search"
+          placeholder={t('placeholder')}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onFocus={() => query.trim() && setIsOpen(true)}
+          onKeyDown={handleKeyDown}
+          rightIcon={query ? <X size={16} /> : undefined}
+          onRightClick={clearSearch}
+          role="combobox"
+          aria-expanded={isOpen}
+          aria-autocomplete="list"
+          aria-controls="search-results"
+          aria-activedescendant={isOpen && activeIndex >= 0 ? `search-option-${activeIndex}` : undefined}
+          className="placeholder-textcolor-tertiary h-8 border-none bg-background caret-textcolor-primary hover:bg-background-soft focus:placeholder-transparent focus-visible:bg-background-soft"
+          containerClassName="w-full"
+        />
+        {isOpen && (
+          <ul
+            id="search-results"
+            role="listbox"
+            className="absolute top-full z-50 mt-1 max-h-64 w-full overflow-y-auto rounded-md border bg-white shadow-lg"
+          >
+            {filteredItems.length > 0 ? (
+              filteredItems.map((item, index) => (
+                <li key={item.key} id={`search-option-${index}`} role="option" aria-selected={index === activeIndex}>
+                  <Link
+                    href={item.href}
+                    onClick={() => {
+                      clearSearch()
+                      setIsMobileOpen(false)
+                    }}
+                    className={`block px-3 py-2 text-sm ${
+                      index === activeIndex
+                        ? 'bg-background-soft text-textcolor-primary'
+                        : 'text-textcolor-secondary hover:bg-background-soft'
+                    }`}
+                  >
+                    {tMenu(item.key)}
+                  </Link>
+                </li>
+              ))
+            ) : (
+              <li
+                role="option"
+                aria-selected={false}
+                aria-disabled={true}
+                className="text-textcolor-tertiary px-3 py-2 text-sm"
+              >
+                {t('noResults')}
               </li>
-            ))
-          ) : (
-            <li
-              role="option"
-              aria-selected={false}
-              aria-disabled={true}
-              className="text-textcolor-tertiary px-3 py-2 text-sm"
-            >
-              {t('noResults')}
-            </li>
-          )}
-        </ul>
-      )}
+            )}
+          </ul>
+        )}
+      </div>
     </div>
   )
 }

--- a/components/Layout/Header/SearchBar.tsx
+++ b/components/Layout/Header/SearchBar.tsx
@@ -112,7 +112,11 @@ const SearchBar = ({
       >
         <Search size={18} />
       </button>
-
+      {/*
+        Mobile (<tablet): search opens as absolute overlay below header
+        Tablet (tablet-sm): search opens inline inside header
+        Desktop (sm+): search is always visible
+      */}
       <div
         className={cn(isMobileOpen ? 'absolute left-4 right-4 top-14 z-50 flex' : 'hidden sm:block', 'tablet:static')}
       >

--- a/components/Layout/MobileNavDrawer/CompanyMobileNavDrawer.tsx
+++ b/components/Layout/MobileNavDrawer/CompanyMobileNavDrawer.tsx
@@ -26,15 +26,15 @@ export default function CompanyMobileNavDrawer({
         type="button"
         aria-label={t('openNavigation')}
         onClick={() => setOpen(true)}
-        className="flex items-center justify-center text-textcolor-secondary md:hidden"
+        className="flex items-center justify-center text-textcolor-secondary lg:hidden"
       >
         <LucideMenu size={22} />
       </button>
 
-      {open && <div className="fixed inset-0 z-40 bg-black/40 md:hidden" aria-hidden onClick={() => setOpen(false)} />}
+      {open && <div className="fixed inset-0 z-40 bg-black/40 lg:hidden" aria-hidden onClick={() => setOpen(false)} />}
 
       <div
-        className={`fixed inset-y-0 left-0 z-50 flex w-72 flex-col overflow-hidden bg-white shadow-xl transition-transform duration-300 ease-in-out md:hidden ${
+        className={`fixed inset-y-0 left-0 z-50 flex w-72 flex-col overflow-hidden bg-white shadow-xl transition-transform duration-300 ease-in-out lg:hidden ${
           open ? 'translate-x-0' : '-translate-x-full'
         }`}
       >

--- a/components/Layout/MobileNavDrawer/MobileNavDrawer.tsx
+++ b/components/Layout/MobileNavDrawer/MobileNavDrawer.tsx
@@ -21,17 +21,17 @@ export default function MobileNavDrawer() {
         type="button"
         aria-label={t('openNavigation')}
         onClick={() => setOpen(true)}
-        className="flex items-center justify-center text-textcolor-secondary md:hidden"
+        className="flex items-center justify-center text-textcolor-secondary lg:hidden"
       >
         <LucideMenu size={22} />
       </button>
 
       {/* Backdrop */}
-      {open && <div className="fixed inset-0 z-40 bg-black/40 md:hidden" aria-hidden onClick={() => setOpen(false)} />}
+      {open && <div className="fixed inset-0 z-40 bg-black/40 lg:hidden" aria-hidden onClick={() => setOpen(false)} />}
 
       {/* Drawer */}
       <div
-        className={`fixed inset-y-0 left-0 z-50 flex w-72 flex-col overflow-hidden bg-white shadow-xl transition-transform duration-300 ease-in-out md:hidden ${
+        className={`fixed inset-y-0 left-0 z-50 flex w-72 flex-col overflow-hidden bg-white shadow-xl transition-transform duration-300 ease-in-out lg:hidden ${
           open ? 'translate-x-0' : '-translate-x-full'
         }`}
       >

--- a/components/Layout/Sidebar/SidebarMenu.tsx
+++ b/components/Layout/Sidebar/SidebarMenu.tsx
@@ -59,7 +59,7 @@ export default function SidebarMenu({
 
   return (
     <ul
-      className={`flex flex-col max-md:w-full ${type === 'admin' ? 'text-color-white' : 'text-remark overflow-hidden rounded border border-border'}`}
+      className={`sticky top-3 flex flex-col max-md:w-full ${type === 'admin' ? 'text-color-white' : 'text-remark overflow-hidden rounded border border-border'}`}
     >
       {menu.map((item: SidebarMenuItemType) => {
         const isActive = pathname === item.href || pathname.startsWith(item.href + '/')

--- a/components/Layout/TopMenu/TopMenu.tsx
+++ b/components/Layout/TopMenu/TopMenu.tsx
@@ -6,13 +6,22 @@ import { useTranslations } from 'next-intl'
 import { APP_VIEW_TYPE, AppViewType } from '@/constants/general'
 import { TopMenuType } from '@/constants/menu'
 import { Link, usePathname } from '@/i18n/navigation'
+import { cn } from '@/lib/utils'
 
 const iconMap: Record<string, ReactNode> = {
   bookHeart: <BookHeart className="h-5 w-5" size={12} />,
   layoutDashboard: <LayoutDashboard className="h-5 w-5" size={12} />,
 }
 
-const TopMenu = ({ menu, type }: { menu: TopMenuType; type?: AppViewType }) => {
+const TopMenu = ({
+  menu,
+  type,
+  collapseToMyDayOnTablet = false,
+}: {
+  menu: TopMenuType
+  type?: AppViewType
+  collapseToMyDayOnTablet?: boolean
+}) => {
   const t = useTranslations('components.Navbar')
   const pathname = usePathname()
 
@@ -21,14 +30,19 @@ const TopMenu = ({ menu, type }: { menu: TopMenuType; type?: AppViewType }) => {
   return (
     <>
       {/* Desktop */}
-      <nav className="hidden items-center gap-sm font-normal leading-[120%] tracking-normal md:flex wide:gap-md">
+      <nav
+        className={cn(
+          'hidden items-center gap-sm font-normal leading-[120%] tracking-normal md:flex wide:gap-md',
+          collapseToMyDayOnTablet ? 'flex' : ''
+        )}
+      >
         {menu.map((item) => {
           const isActive = pathname === item.href
           return (
             <Link
               key={item.key}
               href={item.href}
-              className={`flex items-center gap-1 whitespace-nowrap transition-colors hover:font-semibold ${isActive ? 'font-semibold text-primary' : textColor}`}
+              className={`flex items-center gap-1 whitespace-nowrap transition-colors hover:font-semibold ${isActive ? 'font-semibold text-primary' : textColor} ${collapseToMyDayOnTablet && item.key !== 'my-day' ? 'hidden desktop:flex' : ''}`}
               aria-current={isActive ? 'page' : undefined}
             >
               {item.icon && iconMap[item.icon]}

--- a/components/Layout/mainVariants.tsx
+++ b/components/Layout/mainVariants.tsx
@@ -1,6 +1,6 @@
 import { cva } from 'class-variance-authority'
 
-export const mainVariants = cva('old-paper min-h-screen w-full flex-1 flex-col items-start justify-between', {
+export const mainVariants = cva('old-paper min-w-0 min-h-screen w-full flex-1 flex-col items-start justify-between', {
   variants: {
     layout: {
       withSidebar: '',

--- a/components/Layout/mainVariants.tsx
+++ b/components/Layout/mainVariants.tsx
@@ -1,0 +1,13 @@
+import { cva } from 'class-variance-authority'
+
+export const mainVariants = cva('old-paper min-h-screen w-full flex-1 flex-col items-start justify-between', {
+  variants: {
+    layout: {
+      withSidebar: '',
+      noSidebar: 'rounded-none',
+    },
+  },
+  defaultVariants: {
+    layout: 'withSidebar',
+  },
+})

--- a/ds/components/CustomInput.tsx
+++ b/ds/components/CustomInput.tsx
@@ -10,6 +10,7 @@ type CustomInputProps = React.InputHTMLAttributes<HTMLInputElement> & {
   label?: string
   errorMsg?: string
   helperText?: string
+  containerClassName?: string
   leftIcon?: React.ReactNode
   rightIcon?: React.ReactNode
   onLeftClick?: () => void
@@ -18,11 +19,23 @@ type CustomInputProps = React.InputHTMLAttributes<HTMLInputElement> & {
 
 export const CustomInput = React.forwardRef<HTMLInputElement, CustomInputProps>(
   (
-    { className, label, errorMsg, helperText, id, leftIcon, rightIcon, onLeftClick, onRightClick, ...inputProps },
+    {
+      className,
+      label,
+      errorMsg,
+      helperText,
+      containerClassName,
+      id,
+      leftIcon,
+      rightIcon,
+      onLeftClick,
+      onRightClick,
+      ...inputProps
+    },
     ref
   ) => {
     return (
-      <div className="flex flex-col gap-1">
+      <div className={cn('flex flex-col gap-1', containerClassName)}>
         {label && <Label htmlFor={id}>{label}</Label>}
         <div className="relative">
           {leftIcon &&

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -433,7 +433,7 @@ body {
   }
 
   .old-paper {
-    @apply flex bg-background-alt md:rounded-[32px];
+    @apply flex bg-background-alt lg:rounded-[32px];
   }
 
   .padded {

--- a/ui/button/button-variants.ts
+++ b/ui/button/button-variants.ts
@@ -1,11 +1,4 @@
-'use client'
-
-import * as React from 'react'
-import { Slot } from '@radix-ui/react-slot'
-import { cva, type VariantProps } from 'class-variance-authority'
-
-import { cn } from '@/lib/utils'
-
+import { cva } from 'class-variance-authority'
 // Shared style patterns for consistency and reusability
 const interactiveStates = {
   primary: 'hover:bg-primary-hover focus:bg-primary-focus active:bg-primary-pressed',
@@ -45,7 +38,7 @@ const iconButtonStyles = `bg-transparent text-iconcolor-primary hover:bg-backgro
 
 const volumeButtonStyles = `px-6 py-4 bg-primary text-primary-foreground ${interactiveStates.primary} ${focusRing.primary} shadow-md [background-image:linear-gradient(45deg,rgba(31,210,192,0)_60%,rgba(31,210,192,0.5)_80%,rgba(255,255,255,0.5)_100%)] [box-shadow:inset_0px_2px_4px_rgba(255,255,255,0.3)] [-webkit-font-smoothing:antialiased] [-moz-osx-font-smoothing:grayscale] disabled:[background-image:none]`
 
-const buttonVariants = cva(
+export const buttonVariants = cva(
   'inline-flex items-center justify-center whitespace-normal rounded-full text-base leading-none transition-colors focus:outline-none disabled:pointer-events-none disabled:bg-background-muted disabled:text-textcolor-muted disabled:[text-shadow:0_1px_0_hsla(0,0%,100%,0.8)] [&_svg]:pointer-events-none [&_svg]:shrink-0 h-10',
   {
     variants: {
@@ -96,18 +89,3 @@ const buttonVariants = cva(
     ],
   }
 )
-
-export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
-  asChild?: boolean
-}
-
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : 'button'
-    return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
-  }
-)
-Button.displayName = 'Button'
-
-export { Button, buttonVariants }

--- a/ui/button/button.tsx
+++ b/ui/button/button.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'
+import { type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/lib/utils'
+
+import { buttonVariants } from './button-variants'
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button'
+    return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+  }
+)
+Button.displayName = 'Button'
+
+export { Button }

--- a/ui/button/index.ts
+++ b/ui/button/index.ts
@@ -1,0 +1,2 @@
+export { Button } from './button'
+export { buttonVariants } from './button-variants'


### PR DESCRIPTION
Style: #386 

Affects all nested pages under:
- `app/[locale]/(protected)/.../page.tsx`
- `app/[locale]/company/.../page.tsx`

Changes:
1. Updated sidebar breakpoint: visible >=1024px; otherwise hidden and accessible via burger menu 
2. Updated spacing between header and page content (now responsive instead of fixed) 
3. Set minimum width for < main > to prevent horizontal scrolling
4. Updated header on mobile (added search icon; My Day link moved from Sidebar to Header)
5. Updated SearchBar component (added mobile support)
6. Updated burger menu breakpoint (hidden from lg instead of md)
7. Made Sidebar items sticky
8. Updated CustomInput component (added containerClassName prop)
9. Updated old-paper styles (rounded corners on lg screens)
10. Moved button style options to a separate file (previously in client component, caused issues on server)