### PR TITLE
fix: hide extra icon tools for create-personal-goal-card

### DIFF
--- a/components/features/MyProgress/PersonalGoals/CreatePersonalGoalButton.tsx
+++ b/components/features/MyProgress/PersonalGoals/CreatePersonalGoalButton.tsx
@@ -11,6 +11,7 @@ export const CreatePersonalGoalButton = ({ text, onClick }: CreatePersonalGoalBu
     <Card
       onClick={onClick}
       className="ring-outline-secondary group flex h-full min-h-40 flex-col items-center justify-center gap-sm rounded-md p-6 ring-1 ring-inset hover:cursor-pointer hover:ring-2 hover:ring-primary-hover"
+      hideTools={true}
     >
       <div className="text-primary group-hover:text-primary-hover">
         <AddIcon />

--- a/components/features/MyProgress/PersonalGoals/CreatePersonalGoalButton.tsx
+++ b/components/features/MyProgress/PersonalGoals/CreatePersonalGoalButton.tsx
@@ -11,7 +11,7 @@ export const CreatePersonalGoalButton = ({ text, onClick }: CreatePersonalGoalBu
     <Card
       onClick={onClick}
       className="ring-outline-secondary group flex h-full min-h-40 flex-col items-center justify-center gap-sm rounded-md p-6 ring-1 ring-inset hover:cursor-pointer hover:ring-2 hover:ring-primary-hover"
-      hideTools={true}
+      hideLinkIndicator={true}
     >
       <div className="text-primary group-hover:text-primary-hover">
         <AddIcon />

--- a/components/shared/Cards/Card.tsx
+++ b/components/shared/Cards/Card.tsx
@@ -25,6 +25,7 @@ interface CardProps {
   children?: ReactNode
   tags?: string[]
   tools?: ReactNode | ReactNode[]
+  hideTools?: boolean
   link?: string
   linkText?: string
   onClick?: () => void
@@ -47,6 +48,7 @@ const Card = ({
   type = Statuses.default,
   tags,
   tools,
+  hideTools = false,
   link,
   linkText,
   onClick,
@@ -104,7 +106,7 @@ const Card = ({
             </div>
             <div className={`relative z-10 flex gap-1 ${isDark ? 'tools-dark' : ''}`} data-card-tools>
               {tools && (Array.isArray(tools) ? tools.map((tool, idx) => <span key={idx}>{tool}</span>) : tools)}
-              {(link || onClick) && (
+              {!hideTools && (link || onClick) && (
                 <span className={cn('flex items-center gap-1 opacity-65', link && 'pointer-events-none')}>
                   {linkText}
                   <SquareArrowOutUpRight size={16} />

--- a/components/shared/Cards/Card.tsx
+++ b/components/shared/Cards/Card.tsx
@@ -25,7 +25,7 @@ interface CardProps {
   children?: ReactNode
   tags?: string[]
   tools?: ReactNode | ReactNode[]
-  hideTools?: boolean
+  hideLinkIndicator?: boolean
   link?: string
   linkText?: string
   onClick?: () => void
@@ -48,7 +48,7 @@ const Card = ({
   type = Statuses.default,
   tags,
   tools,
-  hideTools = false,
+  hideLinkIndicator = false,
   link,
   linkText,
   onClick,
@@ -106,7 +106,7 @@ const Card = ({
             </div>
             <div className={`relative z-10 flex gap-1 ${isDark ? 'tools-dark' : ''}`} data-card-tools>
               {tools && (Array.isArray(tools) ? tools.map((tool, idx) => <span key={idx}>{tool}</span>) : tools)}
-              {!hideTools && (link || onClick) && (
+              {!hideLinkIndicator && (link || onClick) && (
                 <span className={cn('flex items-center gap-1 opacity-65', link && 'pointer-events-none')}>
                   {linkText}
                   <SquareArrowOutUpRight size={16} />


### PR DESCRIPTION
Fix: #399 